### PR TITLE
Security: Update package name

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "editor-devel",
+  "name": "qwilr-editor-devel",
   "description": "editor devel helper only",
   "version": "0.0.1",
   "main": "./client.js",


### PR DESCRIPTION
## Summary
The package currently has a name of `editor-devel` which is an known malicious dependency that has been blocked in NPM.  This PR changes the name to avoid false-positives in our monitoring tools, such as AWS inspector.

## Test
Update qwilr/package.json to correct commit version and put through build pipeline.

## Rollback
Can be reverted